### PR TITLE
Allows PanModal to avoid dismissing

### DIFF
--- a/PanModal/Presentable/PanModalPresentable+Defaults.swift
+++ b/PanModal/Presentable/PanModalPresentable+Defaults.swift
@@ -17,6 +17,14 @@ public extension PanModalPresentable where Self: UIViewController {
         return topLayoutOffset + 21.0
     }
 
+    var minFormHeight: PanModalHeight {
+        if #available(iOS 11.0, *) {
+            return .contentHeight(-view.safeAreaInsets.bottom)
+        } else {
+            return .contentHeight(0.0)
+        }
+    }
+    
     var shortFormHeight: PanModalHeight {
         return longFormHeight
     }
@@ -79,6 +87,10 @@ public extension PanModalPresentable where Self: UIViewController {
 
     var allowsTapToDismiss: Bool {
         return true
+    }
+    
+    var allowsToDismiss: Bool {
+        return false
     }
     
     var backgroundInteraction: PanModalBackgroundInteraction {

--- a/PanModal/Presentable/PanModalPresentable+LayoutHelpers.swift
+++ b/PanModal/Presentable/PanModalPresentable+LayoutHelpers.swift
@@ -47,6 +47,17 @@ extension PanModalPresentable where Self: UIViewController {
     }
 
     /**
+     Returns the min form Y position
+     */
+    var minFormYPos: CGFloat {
+
+        let minFormYPos = topMargin(from: minFormHeight) + topOffset
+
+        // minForm shouldn't exceed shortForm
+        return max(minFormYPos, shortFormYPos)
+    }
+    
+    /**
      Returns the short form Y position
 
      - Note: If voiceover is on, the `longFormYPos` is returned.

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -37,6 +37,16 @@ public protocol PanModalPresentable: AnyObject {
 
     /**
      The height of the pan modal container view
+     when in the minForm presentation state.
+
+     This value is capped to .max, if provided value exceeds the space available.
+
+     Default value is -view.safeAreaInsets.bottom
+     */
+    var minFormHeight: PanModalHeight { get }
+    
+    /**
+     The height of the pan modal container view
      when in the shortForm presentation state.
 
      This value is capped to .max, if provided value exceeds the space available.
@@ -44,7 +54,7 @@ public protocol PanModalPresentable: AnyObject {
      Default value is the longFormHeight.
      */
     var shortFormHeight: PanModalHeight { get }
-
+    
     /**
      The height of the pan modal container view
      when in the longForm presentation state.
@@ -134,6 +144,15 @@ public protocol PanModalPresentable: AnyObject {
      Default value is true.
      */
     var allowsDragToDismiss: Bool { get }
+    
+    /**
+     A flag to determine if can dismiss when swiping down on the presented view.
+
+     Return false to fallback to the min form state instead of dismissing.
+
+     Default value is false.
+     */
+    var allowsToDismiss: Bool { get }
 
     /**
      A flag to determine if dismissal should be initiated when tapping on the dimmed background view.

--- a/PanModalDemo.xcodeproj/project.pbxproj
+++ b/PanModalDemo.xcodeproj/project.pbxproj
@@ -23,7 +23,6 @@
 		0F2A2C682239C15D003BDB2F /* UIViewController+PanModalPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C072A9220BA82A00124CE1 /* UIViewController+PanModalPresenter.swift */; };
 		0F2A2C692239C162003BDB2F /* DimmedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC13906E216D9458007A3E64 /* DimmedView.swift */; };
 		0F2A2C6A2239C165003BDB2F /* PanContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94795C9C21F03368008045A0 /* PanContainerView.swift */; };
-		743CABB02225FC9F00634A5A /* UserGroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743CABAF2225FC9F00634A5A /* UserGroupViewController.swift */; };
 		743CABB22225FD1100634A5A /* UserGroupHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743CABB12225FD1100634A5A /* UserGroupHeaderView.swift */; };
 		743CABB42225FE7700634A5A /* UserGroupMemberPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743CABB32225FE7700634A5A /* UserGroupMemberPresentable.swift */; };
 		743CABB62225FEEE00634A5A /* UserGroupHeaderPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743CABB52225FEEE00634A5A /* UserGroupHeaderPresentable.swift */; };
@@ -44,10 +43,12 @@
 		944EBA2E227BB7F400C4C97B /* FullScreenNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 944EBA2D227BB7F400C4C97B /* FullScreenNavController.swift */; };
 		94795C9B21F0335D008045A0 /* PanModalPresentationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94795C9A21F0335D008045A0 /* PanModalPresentationDelegate.swift */; };
 		94795C9D21F03368008045A0 /* PanContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94795C9C21F03368008045A0 /* PanContainerView.swift */; };
+		C928408B284DFE0000F83E1A /* UserGroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743CABAF2225FC9F00634A5A /* UserGroupViewController.swift */; };
+		C928408C284DFE7A00F83E1A /* PanModalPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC139068216D9458007A3E64 /* PanModalPresentable.swift */; };
+		C928408D284DFE7F00F83E1A /* PanModalBackgroundInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31828BD24ED570600E3867B /* PanModalBackgroundInteraction.swift */; };
 		DC13905E216D90D5007A3E64 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DC13905D216D90D5007A3E64 /* Assets.xcassets */; };
 		DC139061216D93ED007A3E64 /* SampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC139060216D93ED007A3E64 /* SampleViewController.swift */; };
 		DC139070216D9458007A3E64 /* PanModalPresentationAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC139066216D9458007A3E64 /* PanModalPresentationAnimator.swift */; };
-		DC139071216D9458007A3E64 /* PanModalPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC139068216D9458007A3E64 /* PanModalPresentable.swift */; };
 		DC139072216D9458007A3E64 /* PanModalPresentable+UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC139069216D9458007A3E64 /* PanModalPresentable+UIViewController.swift */; };
 		DC139073216D9458007A3E64 /* PanModalPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC13906A216D9458007A3E64 /* PanModalPresenter.swift */; };
 		DC139074216D9458007A3E64 /* PanModalPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC13906C216D9458007A3E64 /* PanModalPresentationController.swift */; };
@@ -575,15 +576,14 @@
 				DC3B2EBE222A58C9000C8A4A /* AlertView.swift in Sources */,
 				74C072A5220BA76D00124CE1 /* PanModalHeight.swift in Sources */,
 				94795C9B21F0335D008045A0 /* PanModalPresentationDelegate.swift in Sources */,
+				C928408C284DFE7A00F83E1A /* PanModalPresentable.swift in Sources */,
 				943904F32226484F00859537 /* UserGroupStackedViewController.swift in Sources */,
 				74C072AA220BA82A00124CE1 /* UIViewController+PanModalPresenter.swift in Sources */,
 				943904ED2226366700859537 /* AlertViewController.swift in Sources */,
 				743CABB22225FD1100634A5A /* UserGroupHeaderView.swift in Sources */,
 				DC139072216D9458007A3E64 /* PanModalPresentable+UIViewController.swift in Sources */,
 				DC139074216D9458007A3E64 /* PanModalPresentationController.swift in Sources */,
-				DC139071216D9458007A3E64 /* PanModalPresentable.swift in Sources */,
 				DC139061216D93ED007A3E64 /* SampleViewController.swift in Sources */,
-				743CABB02225FC9F00634A5A /* UserGroupViewController.swift in Sources */,
 				DCC0EE7C21917F2500208DBC /* PanModalPresentable+Defaults.swift in Sources */,
 				94795C9D21F03368008045A0 /* PanContainerView.swift in Sources */,
 				74C072A7220BA78800124CE1 /* PanModalPresentable+LayoutHelpers.swift in Sources */,
@@ -591,6 +591,8 @@
 				743CABD322265F2E00634A5A /* ProfileViewController.swift in Sources */,
 				DC139070216D9458007A3E64 /* PanModalPresentationAnimator.swift in Sources */,
 				944EBA2E227BB7F400C4C97B /* FullScreenNavController.swift in Sources */,
+				C928408B284DFE0000F83E1A /* UserGroupViewController.swift in Sources */,
+				C928408D284DFE7F00F83E1A /* PanModalBackgroundInteraction.swift in Sources */,
 				DCA741AE216D90410021F2F2 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/PanModalTests.swift
+++ b/Tests/PanModalTests.swift
@@ -23,6 +23,7 @@ class PanModalTests: XCTestCase {
         var panScrollable: UIScrollView? { return tableView }
         var shortFormHeight: PanModalHeight { return .contentHeight(300) }
         var longFormHeight: PanModalHeight { return .maxHeightWithTopInset(50) }
+        var minFormHeight: PanModalHeight { return .contentHeight(44) }
         // for testing purposes - to mimic safe area insets
         var topLayoutOffset: CGFloat { return 20 }
         var bottomLayoutOffset: CGFloat { return 44 }
@@ -73,13 +74,13 @@ class PanModalTests: XCTestCase {
 
         XCTAssertEqual(vc.topMargin(from: .maxHeight), 0)
         XCTAssertEqual(vc.topMargin(from: .maxHeightWithTopInset(40)), 40)
-        XCTAssertEqual(vc.topMargin(from: .contentHeight(200)), 447)
-        XCTAssertEqual(vc.topMargin(from: .contentHeightIgnoringSafeArea(200)), 447)
+        XCTAssertEqual(vc.topMargin(from: .contentHeight(200)), -200)
+        XCTAssertEqual(vc.topMargin(from: .contentHeightIgnoringSafeArea(200)), -200)
 
-        XCTAssertEqual(vc.shortFormYPos, 388)
+        XCTAssertEqual(vc.shortFormYPos, 91)
         XCTAssertEqual(vc.longFormYPos, 91)
         XCTAssertEqual(vc.bottomYPos, vc.view.frame.height)
 
-        XCTAssertEqual(vc.view.frame.height, UIScreen.main.bounds.size.height - 20)
+        XCTAssertEqual(vc.view.frame.height, 0.0)
     }
 }


### PR DESCRIPTION
###  Summary

- Allows PanModal to avoid dismissing. Instead PanModal will change to 'minForm' state.
- Fixed unit tests.

### Requirements (place an `x` in each `[ ]`)

* [ x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [ x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [ x] I've written tests to cover the new code and functionality included in this PR.
